### PR TITLE
Customizable formatting

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -1,5 +1,6 @@
 gulp = require 'gulp'
 concat = require 'gulp-concat'
+pug = require 'gulp-pug'
 
 gulp.task 'clean', ->
     require('del') ['dist', 'bin']
@@ -29,11 +30,25 @@ gulp.task 'build:content:css', ->
 gulp.task 'build:background', ->
     gulp.src([
             'node_modules/jquery/dist/jquery.min.js'
+            'src/scripts/shared/storage.js'
             'src/scripts/background/clipboard.js'
             'src/scripts/background/background.js'
         ])
         .pipe concat 'background.js'
         .pipe gulp.dest 'dist/scripts'
+
+gulp.task 'build:options:js', ->
+    gulp.src([
+            'src/scripts/shared/storage.js'
+            'src/options/*.js'
+        ])
+        .pipe concat 'options.js'
+        .pipe gulp.dest 'dist/scripts'
+
+gulp.task 'build:options:page', ->
+    gulp.src('src/options/options.pug')
+        .pipe pug()
+        .pipe gulp.dest 'dist/options'
 
 gulp.task 'copy:manifest', ->
     gulp.src 'src/manifest.json'
@@ -46,6 +61,8 @@ gulp.task 'copy:images', ->
 gulp.task 'build', [
     'build:content:js'
     'build:content:css'
+    'build:options:js'
+    'build:options:page'
     'build:background'
     'copy:scripts'
     'copy:manifest'
@@ -53,9 +70,12 @@ gulp.task 'build', [
 ]
 
 gulp.task 'watch', ->
+    gulp.watch 'src/shared/*.js',             ['build:background', 'build:options:js']
     gulp.watch 'src/scripts/background/*.js', ['build:background']
     gulp.watch 'src/scripts/content/*.js',    ['build:content:js']
     gulp.watch 'src/scripts/content/*.css',   ['build:content:css']
+    gulp.watch 'src/options/*.js',            ['build:options:js']
+    gulp.watch 'src/options/options.pug',     ['build:options:page']
     gulp.watch 'src/scripts/*.js',            ['copy:scripts']
     gulp.watch 'src/manifest.json',           ['copy:manifest']
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "coffee-script": "^1.11.1",
     "del": "^2.2.2",
     "gulp": "^3.9.1",
-    "gulp-concat": "^2.6.1"
+    "gulp-concat": "^2.6.1",
+    "gulp-pug": "^3.3.0"
   },
   "dependencies": {
     "jquery": "^3.1.1",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -56,5 +56,9 @@
       },
       "description": "Copy issue to Email"
     }
+  },
+  "options_ui": {
+    "page": "options/options.html",
+    "chrome_style": true
   }
 }

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,0 +1,30 @@
+function ready(fn) {
+    if (document.readyState != 'loading') {
+        fn();
+    } else {
+        document.addEventListener('DOMContentLoaded', fn);
+    }
+}
+
+getValue = (selector) =>
+    document.getElementById(selector).value;
+
+setValue = (selector, value) =>
+    document.getElementById(selector).value = value;
+
+ready(() => {
+    storage.getCustomFontFamily()
+        .then(fontFamily => setValue('copy-custom-font-family', fontFamily));
+
+    storage.getCustomFontSize()
+        .then(fontSize => setValue('copy-custom-font-size', fontSize));
+})
+
+document.getElementById('save')
+    .addEventListener('click', () => {
+        storage.setCustomFontFamily(getValue('copy-custom-font-family'));
+        storage.setCustomFontSize(getValue('copy-custom-font-size'));
+        chrome.runtime.sendMessage({
+            type: 'options-changed'
+        }, close);
+    });

--- a/src/options/options.pug
+++ b/src/options/options.pug
@@ -1,0 +1,30 @@
+doctype html
+head
+    title Rally Copy Helper | Options
+    style.
+        select { width: 200px; margin: 15px auto; display: block; }
+body
+    section
+        h1 Options
+
+        h3 Font of content copied to clipboard
+
+        select#copy-custom-font-family
+            option none
+            option Segoe UI
+            option Verdana
+            option Calibri
+            option Arial
+            option Tahoma
+
+        select#copy-custom-font-size
+            option none
+            option 10pt
+            option 11pt
+            option 12pt
+            option 13pt
+    hr
+    center
+        button#save Save
+    
+    script(src='/scripts/options.js')

--- a/src/scripts/background/background.js
+++ b/src/scripts/background/background.js
@@ -17,7 +17,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     case 'copy-to-clipboard': {
       let { Url, Title, Id } = message.data;
       clipboard.copy({
-        html: `<a href='${Url}'>${Id}</a>: <em>${Title}</em>`,
+        html: `<a href='${Url}'>${Id}</a>: <em>${Title}</em><br><p></p>`,
         text: `${Id}: ${Title}`
       });
       sendResponse({isSuccess: true});

--- a/src/scripts/shared/storage.js
+++ b/src/scripts/shared/storage.js
@@ -1,0 +1,47 @@
+const DEFAULTS = {
+  fontFamily: 'Calibri',
+  fontSize: '11pt'
+}
+
+class Storage {
+
+  constructor() { // Set Defaults
+    this.getCustomFontFamily()
+    .then(fontFamily => fontFamily ? null : this.setCustomFontFamily(DEFAULTS.fontFamily));
+
+    this.getCustomFontSize()
+    .then(fontSize => fontSize ? null : this.setCustomFontSize(DEFAULTS.fontSize));
+  }
+
+  get(propertyKey) {
+    return new Promise((resolve, reject) => {
+      chrome.storage.local.get(propertyKey, o => resolve(o[propertyKey]));
+    })
+  }
+
+  set(propertyKey, value) {
+    let o = {};
+    o[propertyKey] = value;
+    chrome.storage.local.set(o);
+  }
+
+  ////////////////////////////////////////
+  // Configuration
+  //
+
+  setCustomFontFamily(fontFamily) {
+    this.set('FONT_FAMILY', fontFamily);
+  }
+  getCustomFontFamily() {
+    return this.get('FONT_FAMILY');
+  }
+
+  setCustomFontSize(fontSize) {
+    this.set('FONT_SIZE', fontSize);
+  }
+  getCustomFontSize() {
+    return this.get('FONT_SIZE');
+  }
+}
+
+const storage = new Storage();


### PR DESCRIPTION
Changes for "copy to clipboard":

1. Added line break after italic-styled title of the issue (resolves problem reported in comment on Chrome Store)
1. Added ability set custom font family and size from the provided rage of options
1. Setting default format to `Calibri` / `11pt`

![image](https://cloud.githubusercontent.com/assets/20162853/24734637/c43553f4-1a7e-11e7-9cd5-9d4662e313f5.png)

![image](https://cloud.githubusercontent.com/assets/20162853/24734697/ff01641e-1a7e-11e7-8289-6786736bb1cc.png)

Closes #3 